### PR TITLE
Change requirement to official name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.6",
-    install_requires=["requests", "bs4", "typing", "typing_extensions"],
+    install_requires=["requests", "beautifulsoup4", "typing", "typing_extensions"],
     extras_require={"cli": ["click"], "colour": ["colorama"]},
 )


### PR DESCRIPTION
bs4 is just an alias to beautifulsoup4 and it took me a moment to figure that out, searching bs4 in my system package manager, while beautifulsoup4 was already installed