### PR TITLE
Require Py ≥ 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 urls = {Homepage = "https://github.com/Starwort/aoc_helper"}
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 dependencies = [
     "requests",
     "beautifulsoup4",


### PR DESCRIPTION
Assignment expressions ([PEP-572](https://peps.python.org/pep-0572/)) as used in https://github.com/Starwort/aoc_helper/blob/88c03b6cdba632d39e66f2b3be269ff361fba5f0/aoc_helper/interface.py#L185
(and other places) require Python &GreaterEqual; 3.8.

Might also be possible to stick with Python &GreaterEqual; 3.6 by avoiding the new syntax.